### PR TITLE
Handle 204 No Content responses when expecting JSON

### DIFF
--- a/can-ajax.js
+++ b/can-ajax.js
@@ -111,7 +111,7 @@ var _xhrResp = function (xhr, options) {
 		case "application/javascript":
 		case "application/x-javascript":
 		case "json":
-			return JSON.parse(xhr.responseText);
+			return xhr.responseText && JSON.parse(xhr.responseText);
 		default:
 			return xhr.responseText;
 	}


### PR DESCRIPTION
Fixes #19 

Basically don't try to `JSON.parse()` blank or empty string responses.