### PR TITLE
Update can-ajax.js

### DIFF
--- a/can-ajax.js
+++ b/can-ajax.js
@@ -73,8 +73,6 @@ var xhrs = [
 		function () { return new ActiveXObject("MSXML2.XMLHTTP"); }
 	],
 	_xhrf = null;
-// used to check for Cross Domain requests
-var originUrl = parseURI(Global().location.href);
 
 var globalSettings = {};
 
@@ -161,6 +159,8 @@ function ajax(o) {
 	//how jquery handles check for cross domain
 	if(o.crossDomain == null){
 		try {
+			// used to check for Cross Domain requests
+			var originUrl = parseURI(Global().location.href);
 			requestUrl = parseURI(o.url);
 			o.crossDomain = !!((requestUrl.protocol && requestUrl.protocol !== originUrl.protocol) ||
 				(requestUrl.host && requestUrl.host !== originUrl.host));


### PR DESCRIPTION
Fixes usage inside Node when loaded via nodejs
```js
(node:12721) ExperimentalWarning: The ESM module loader is experimental.
TypeError: Cannot read property 'href' of undefined
    at Object.<anonymous> (/home/frank/example-es6-loader/stealify-view/canjs/canjs-master/node_modules/can-ajax/dist/cjs/can-ajax.js:22:43)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
    at Module.load (internal/modules/cjs/loader.js:599:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
    at Function.Module._load (internal/modules/cjs/loader.js:530:3)
    at Module.require (internal/modules/cjs/loader.js:637:17)
    at require (internal/modules/cjs/helpers.js:20:18)
    at Object.<anonymous> (/home/frank/example-es6-loader/stealify-view/canjs/canjs-master/node_modules/can-connect/data/url/url.js:98:12)
    at Module._compile (internal/modules/cjs/loader.js:689:30)


```