### PR TITLE
67 - replace `const` with `var`

### DIFF
--- a/can-ajax.js
+++ b/can-ajax.js
@@ -265,7 +265,7 @@ function ajax(o) {
 	}
 
 	if(o.beforeSend){
-		const result = o.beforeSend.call( o, xhr, o );
+		var result = o.beforeSend.call( o, xhr, o );
 		if(canReflect.isPromise(result)) {
 			result.then(send).catch(deferred.reject);
 			return promise;


### PR DESCRIPTION
Use `var` instead of `const` to prevent `strict` syntax error

closes #67